### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 11
         uses: actions/setup-java@v1


### PR DESCRIPTION
By default GitHub only fetches the last commit. An additional setting must be specified to pull all history otherwise the changelog generated by JReleaser will contain just a single entry.