### PR TITLE
fix(security): Upgrade pac4j to 4.5.9 for CVE-2026-29000

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.boot.version>2.7.0</spring.boot.version>
-        <pac4j.version>4.5.6</pac4j.version>
+        <pac4j.version>4.5.9</pac4j.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Summary
Upgrades pac4j from 4.5.6 to 4.5.9 to fix CVE-2026-29000.

## Security Issue
CVE-2026-29000 is a critical (CVSS 9.1) JWT authentication bypass vulnerability.

## Changes
- Updated pac4j version (minor bump, backward compatible)